### PR TITLE
Adding Neoflash Hat LED matrix support

### DIFF
--- a/src/a_GLOBAL/a_GLOBAL.ino
+++ b/src/a_GLOBAL/a_GLOBAL.ino
@@ -3,6 +3,7 @@
 #include <PinButton.h>
 #include <WebServer.h>
 #include <Preferences.h>
+#include "FastLED.h"    //NEEDED FOR NEOFLASH HAT
 
 #define LED_BUILTIN 10
 
@@ -16,3 +17,12 @@ String M_TALLY = "";
 int VMIX_PORT = 8099; //USES THE TCP API PORT, THIS IS FIXED IN VMIX
 int TALLY_NR = 1;
 int BRIGHTNESS = 12; //100%
+
+// NEOFLASH HAT LED STRIP VARIABLES (NOT NEEDED IF YOU DON'T HAVE THE HAT ON)
+// YOU SHOULD ONLY NEED TO ADJUST NEOFLASH_BRIGHTNESS
+#define NEOFLASH_BRIGHTNESS     46    //VALUE FROM 0 TO 255
+#define DATA_PIN    26
+#define LED_TYPE    WS2811
+#define COLOR_ORDER GRB
+#define NUM_LEDS    126
+CRGB leds[NUM_LEDS];

--- a/src/a_GLOBAL/c_MAIN.ino
+++ b/src/a_GLOBAL/c_MAIN.ino
@@ -39,6 +39,10 @@ void setup()
   Serial.println(&(WIFI_SSID[0]));
   Serial.print("PASS: ");
   Serial.println(&(WIFI_PASS[0]));
+
+  // NEOFLASH HAT LED strip configuration
+  FastLED.addLeds<LED_TYPE,DATA_PIN,COLOR_ORDER>(leds, NUM_LEDS).setCorrection(TypicalLEDStrip);
+  FastLED.setBrightness(NEOFLASH_BRIGHTNESS);
 }
 
 void loop()
@@ -178,6 +182,8 @@ void resetScreen(){
   M5.Lcd.fillScreen(TFT_BLACK);
   M5.Lcd.setTextSize(1);
   M5.Lcd.setTextColor(WHITE, BLACK);
+  FastLED.clear();    // CLEAR NEOFLASH HAT IF THERE IS ONE
+  FastLED.show();
 }
 
 void renderBatteryLevel() {

--- a/src/a_GLOBAL/d_VMIX.ino
+++ b/src/a_GLOBAL/d_VMIX.ino
@@ -67,7 +67,9 @@ void setTallyProgram()
     M5.Lcd.setCursor(30, 70);
     M5.Lcd.println("L");
   }
-    
+  
+  fill_solid( leds, NUM_LEDS, CRGB::Red);
+  FastLED.show();
 }
 
 void setTallyPreview() {
@@ -81,6 +83,9 @@ void setTallyPreview() {
     M5.Lcd.setCursor(30, 70);
     M5.Lcd.println("P");
   }
+  
+  fill_solid( leds, NUM_LEDS, CRGB::Green);
+  FastLED.show();
 }
 
 void setTallyOff() {
@@ -94,6 +99,10 @@ void setTallyOff() {
     M5.Lcd.setCursor(30, 70);
     M5.Lcd.println("S");
   }
+  
+  //fill_solid( leds, NUM_LEDS, CRGB::Black);
+  FastLED.clear();
+  FastLED.show();
 }
 
 // Handle incoming data


### PR DESCRIPTION
Hi Guido, I added Neoflash Hat LED matrix support, please see what you think, and if you'd like to pull.  I've tested it out and seems to work with or without the hat on.  See a video here:

https://www.facebook.com/dirwinc/videos/10220539894400616

Pretty basic code.  It requires the FastLED library.  I'm open for any coding changes.

A future improvement might be adding a separate brightness setting on the access point web UI.  I'm thinking the Neoflash brightness should be kept separate from the Stick screen brightness.  FastLED needs a brightness value between 0 to 255.  If you'd be willing to add that, I'd greatly appreciate it!  

Another future improvement might be to add text ('Live', 'Pre', 'Safe') to the LED matrix, but that might be unnecessary, and not that important in my opinion.

Thanks,
Dirwin